### PR TITLE
Argument raw_data returns Python objects instead of default string values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,35 @@
 # petl_odoo
 Provide Odoo io functionality for petl
 
-Example:  
+Example:
 
-	import petl as etl  
-	from petl.util.base import Table  
-	from petlodoo.io.odoo import Odoo, fromodoo, toodoo  
+	import petl as etl
+	from petl.util.base import Table
+	from petlodoo.io.odoo import Odoo, fromodoo, toodoo
 	
-	# Initialize connection to Odoo  
-	odoo = Odoo('http://10.200.12.20:8069', 'test', 'admin', 'admin')  
+	# Initialize connection to Odoo
+	odoo = Odoo('http://10.200.12.20:8069', 'test', 'admin', 'admin')
 	
-	# Get data from Odoo  
-	table1 = fromodoo(odoo, 'product.template', [], ['name', 'standard_price', 'create_date'])  
-	print table1 
+	# Get data from Odoo
+	table1 = fromodoo(odoo, 'product.template', [], ['name', 'standard_price', 'create_date'])
+	print table1
 	# Or in case we have unicode
-	print table1.__unicode__   
+	print table1.__unicode__
 	
-	# Remove columns from data set  
-	table2 = etl.cutout(table1, 'standard_price', 'create_date')  
-	print table2  
+	# Remove columns from data set
+	table2 = etl.cutout(table1, 'standard_price', 'create_date')
+	print table2
 	
-	# Rename all products in set  
-	table3 = etl.convert(table2, 'name', lambda v: v+'(2)')  
-	print table3  
+	# Rename all products in set
+	table3 = etl.convert(table2, 'name', lambda v: v+'(2)')
+	print table3
 	
-	# Write set back to Odoo  
-	toodoo(table3, odoo, 'product.template', batch=500, tracking_disable=True)  
+	# Write set back to Odoo
+	toodoo(table3, odoo, 'product.template', batch=500, tracking_disable=True)
 
-
-
-
+	# Argument raw_data returns Python objects instead of default string values.
+	# Several types can be marshelled/unmarshelled from XML to Python.
+	# See: https://docs.python.org/3/library/xmlrpc.client.html
+	# Set `raw_data` argument (6th position) to True, to get Python objects, e.g. int, datetime.
+	table4 = fromodoo(odoo, 'product.template', [], ['name', 'standard_price', 'create_date'], True)
+	print table4

--- a/petlodoo/io/odoo.py
+++ b/petlodoo/io/odoo.py
@@ -10,8 +10,8 @@ else:
 from petl.util.base import Table
 
 
-def fromodoo(source, model, domain=None, fields=None, batch=100):
-    return OdooView(source, model, domain, fields, batch)
+def fromodoo(source, model, domain=None, fields=None, batch=100, raw_data=False):
+    return OdooView(source, model, domain, fields, batch, raw_data)
 
 
 def toodoo(tbl, source, model, batch=100, tracking_disable=False):
@@ -65,10 +65,11 @@ class OdooView(Table):
     _fields = []
     _batch = None
 
-    def __init__(self, source, model, domain=None, fields=None, batch=None):
+    def __init__(self, source, model, domain=None, fields=None, batch=None, raw_data=False):
         self._source = source
         self._model = model
         self._batch = batch
+        self._raw_data = raw_data
         if domain:
             self._domain = domain
         if fields:
@@ -85,5 +86,5 @@ class OdooView(Table):
         yield self._fields
         ids = self._source.execute(self._model, 'search', self._domain)
         for s in [ids[x:x + self._batch] for x in xrange(0, len(ids), self._batch)]:
-            for rec in self._source.execute(self._model, 'export_data', s, self._fields, True)['datas']:
+            for rec in self._source.execute(self._model, 'export_data', s, self._fields, self._raw_data)['datas']:
                 yield rec

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,8 @@
 from distutils.core import setup
 from setuptools import setup, find_packages
 
-
-
 setup(name='petlodoo',
-        version='1.0',
+        version='1.1',
         package_dir={'': '.'},
         #packages=find_packages(),
         packages=['petlodoo', 'petlodoo.io'],


### PR DESCRIPTION
Argument raw_data returns Python objects instead of default string values.
Set `raw_data` argument (6th position) to True, to get Python objects, e.g. int, datetime.